### PR TITLE
Stop needless multihoming

### DIFF
--- a/bin/fusor-undercloud-configurator
+++ b/bin/fusor-undercloud-configurator
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 import netifaces as ni
-import fcntl, socket, struct, sys, re
+import fcntl, socket, struct, sys, re, os
 
 # Thanks http://stackoverflow.com/questions/159137/getting-mac-address
 def getHwAddr(ifname):
@@ -82,11 +82,6 @@ def ip_num_to_addr(ip):
 # discover things about our network interfaces
 nics = ni.interfaces()
 nics.remove('lo')
-
-if len(nics) < 2:
-  print "Error: Undercloud machines must have at least two Network Interfaces."
-  print "Please refer to the OpenStack documentation."
-  exit(1)
 
 nics_with_addresses = {}
 for nic in nics:
@@ -213,3 +208,7 @@ if not force_no_advanced:
 
 write_undercloud_conf(provisioning_nic, ip_number, netmask, gateway, advanced, admin_password)
 
+f = open('/tmp/network.tmp', 'w')
+f.write("GATEWAY=%s" % gateway)
+f.close
+os.system('sudo mv /tmp/network.tmp /etc/sysconfig/network')


### PR DESCRIPTION
Let's just tell users to set up their undercloud with one interface. We configure the host default gateway and the world is a better place with less manual steps.
