### PR TITLE
Allows user to choose default undercloud IP of 192.0.2.254

### DIFF
--- a/bin/fusor-undercloud-configurator
+++ b/bin/fusor-undercloud-configurator
@@ -208,20 +208,23 @@ undercloud_ip = False
 while not valid_ip:
   print
   undercloud_ip = raw_input('Please specify the IP address of the Openstack Director. Be sure that this IP is on the correct subnet and does not interfere with the block given above. [%s] ' % ip_num_to_addr(ip_number + 254))
-  if not re.match('^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$', undercloud_ip):
+  if not undercloud_ip:
+    undercloud_ip = ip_num_to_addr(ip_number + 254)
+    break
+  elif not re.match('^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$', undercloud_ip):
     print "I didn't understand that IP Address, please try again."
     continue
+  else:
+    inputted_subnet = undercloud_ip.split('.')
+    del inputted_subnet[-1]
 
-  inputted_subnet = undercloud_ip.split('.')
-  del inputted_subnet[-1]
-
-  valid_ip = True
-  for i in range(0, 3):
-    if expected_subnet[i] == inputted_subnet[i]:
-      continue
-    print "Entered IP address not on the same subnet as the network gateway, please try again."
-    valid_ip = False
-    break
+    valid_ip = True
+    for i in range(0, 3):
+      if expected_subnet[i] == inputted_subnet[i]:
+        continue
+      print "Entered IP address not on the same subnet as the network gateway, please try again."
+      valid_ip = False
+      break
 
 done = False
 while not done:


### PR DESCRIPTION
Initially wanted IP specification to be explicit, but now allowing default of 192.0.2.254
