### PR TITLE
Added non-interactive mode to undercloud installer

### DIFF
--- a/bin/fusor-undercloud-configurator
+++ b/bin/fusor-undercloud-configurator
@@ -1,14 +1,14 @@
 #!/usr/bin/python
 import netifaces as ni
-import fcntl, socket, struct, sys, re, os
+import fcntl, socket, struct, sys, re, os, yaml
 
 # Thanks http://stackoverflow.com/questions/159137/getting-mac-address
 def getHwAddr(ifname):
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    info = fcntl.ioctl(s.fileno(), 0x8927,  struct.pack('256s', ifname[:15]))
-    return ':'.join(['%02x' % ord(char) for char in info[18:24]])
+  s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+  info = fcntl.ioctl(s.fileno(), 0x8927,  struct.pack('256s', ifname[:15]))
+  return ':'.join(['%02x' % ord(char) for char in info[18:24]])
 
-def write_undercloud_conf(provisioning_nic, ip_number, netmask, gateway, advanced, admin_password):
+def write_undercloud_conf(provisioning_nic, ip_number, undercloud_ip, netmask, gateway, advanced, admin_password):
   sample = open('/usr/share/instack-undercloud/undercloud.conf.sample', 'r')
   conf = open('/home/stack/undercloud.conf', 'w+')
   no_prompt = {}
@@ -31,8 +31,9 @@ def write_undercloud_conf(provisioning_nic, ip_number, netmask, gateway, advance
     if advanced:
       if line.startswith("#"):
         if line.startswith("# "):
-          # print these lines, they explain the upcomming option
-          print line
+          # print these lines only if in interactive mode, they explain the upcoming option
+          if conf_file == None:
+            print line
         else:
           # these lines are the options (generally), parse it and ask
           if ' = ' in line:
@@ -47,7 +48,14 @@ def write_undercloud_conf(provisioning_nic, ip_number, netmask, gateway, advance
 
             if option in defaults:
               default = defaults[option]
-            answer = raw_input('%s? [%s] ' % (option, default))
+            if conf_file != None:
+              try:
+                answer = answer_file["advanced"][option]
+              except KeyError:
+                print "[%s] was not found in answer file" % option
+                answer = None
+            else:
+              answer = raw_input('%s? [%s] ' % (option, default))
             # This is stupid, but: the sample conf file contains "<None>" as
             # the default for the password options. However, if you actually
             # use "<None>" in an un-commented option, the osp installer
@@ -59,7 +67,8 @@ def write_undercloud_conf(provisioning_nic, ip_number, netmask, gateway, advance
               line = option + ' = ' + answer
             else:
               line = option + ' = ' + default
-            print
+            if conf_file == None: 
+              print
     else: # not advanced
       for option in defaults:
         if line.startswith('#%s = ' % option):
@@ -72,12 +81,21 @@ def write_undercloud_conf(provisioning_nic, ip_number, netmask, gateway, advance
   conf.close()
 
 def ip_num_to_addr(ip):
-    octets = []
-    octets.append((ip >> 24) & 0xff)
-    octets.append((ip >> 16) & 0xff)
-    octets.append((ip >> 8) & 0xff)
-    octets.append(ip & 0xff)
-    return '%d.%d.%d.%d' % tuple(octets)
+  octets = []
+  octets.append((ip >> 24) & 0xff)
+  octets.append((ip >> 16) & 0xff)
+  octets.append((ip >> 8) & 0xff)
+  octets.append(ip & 0xff)
+  return '%d.%d.%d.%d' % tuple(octets)
+
+def ip_addr_to_num(ip, netmask):
+  ip_number = 0
+  for octet in ip_addr.split('.'):
+    ip_number = (ip_number << 8) | int(octet)
+  ip_max = 0xffffffff
+  netmask_number = (ip_max << (32 - int(netmask))) & ip_max
+  ip_number = ip_number & netmask_number
+  return ip_number
 
 # discover things about our network interfaces
 nics = ni.interfaces()
@@ -96,6 +114,32 @@ if len(sys.argv) > 1: # getting nic ip addrs
     print "Warning: multiple network interfaces with IP Addresses were found. You will have to decide which is the correct IP Address yourself."
   for nic in nics_with_addresses.keys():
     print "%s: %s" % (nic, nics_with_addresses[nic])
+  exit()
+
+
+# Check if we are using an answer file or not as specified in the parent script
+
+conf_file = os.environ.get('CONF_FILE')
+
+if conf_file != None:                 # Non Interactive Mode
+  with open(conf_file, 'r') as f:
+    answer_file = yaml.load(f)
+  gateway = answer_file["undercloud"]["gateway"]
+  ip_addr = answer_file["undercloud"]["ip_addr"]
+  provisioning_nic = answer_file["undercloud"]["provisioning_nic"]
+  undercloud_ip = answer_file["undercloud"]["undercloud_ip"]
+  advanced = answer_file["advanced"]["specify"]
+  admin_password = answer_file["password"]["admin_password"]
+
+  ip_addr, netmask = ip_addr.split('/')
+  ip_number = ip_addr_to_num(ip_addr, netmask)
+
+  write_undercloud_conf(provisioning_nic, ip_number, undercloud_ip, netmask, gateway, advanced, admin_password)
+
+  f = open('/tmp/network.tmp', 'w')
+  f.write("GATEWAY=%s" % gateway)
+  f.close
+  os.system('sudo mv /tmp/network.tmp /etc/sysconfig/network')
   exit()
 
 # let's make a guess what the provisioning nic should be:
@@ -244,7 +288,7 @@ if not force_no_advanced:
   else:
     advanced = False
 
-write_undercloud_conf(provisioning_nic, ip_number, netmask, gateway, advanced, admin_password)
+write_undercloud_conf(provisioning_nic, ip_number, undercloud_ip, netmask, gateway, advanced, admin_password)
 
 f = open('/tmp/network.tmp', 'w')
 f.write("GATEWAY=%s" % gateway)

--- a/bin/fusor-undercloud-install
+++ b/bin/fusor-undercloud-install
@@ -1,5 +1,33 @@
 #!/bin/bash
 
+interactive=true
+# Check if we are in non-interactive mode
+if [ "$#" -eq 1 ]; then
+  case $1 in
+    --non-interactive)
+    CONF_FILE='/etc/fusor-undercloud-installer/fusor-undercloud-installer.answers.yaml'
+    interactive=false
+    ;;
+    --answer-file=*)
+    CONF_FILE="${1#*=}"
+    interactive=false
+    ;;
+    *)
+    echo 'Invalid argument... staying in interactive mode'
+  esac
+fi
+
+# Check if configuration file exists
+if [ $interactive == false ]; then
+  if [ -f $CONF_FILE ]; then
+    echo "Running in non-interactive mode using answer file: $CONF_FILE "
+  else
+    echo "Answer file not found... Exiting."
+    exit
+  fi
+fi
+export CONF_FILE
+
 # create stack user, become her
 useradd stack
 echo "stack ALL=(root) NOPASSWD:ALL" >> /etc/sudoers.d/stack
@@ -30,8 +58,13 @@ set -e
 echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
 sysctl -p /etc/sysctl.conf
 
-# do the hostname into hosts
-read -e -p "Set your resolvable Fully Qualified Domain Name: " -i $HOSTNAME HOSTNAME
+# Grab the desired hostname from answer file if specified
+if [ $interactive == false ]; then
+  HOSTNAME=`grep ^hostname $CONF_FILE | awk '{print $2}'`
+else
+  # do the hostname into hosts
+  read -e -p "Set your resolvable Fully Qualified Domain Name: " -i $HOSTNAME HOSTNAME
+fi
 hostnamectl set-hostname $HOSTNAME
 hostnamectl set-hostname --transient $HOSTNAME
 # In case we're running this installer again, delete any previous entries
@@ -42,7 +75,13 @@ echo "127.0.0.1 $HOSTNAME `hostname -s`" >> /etc/hosts
 # Ask for DNS server and set it if not already in resolv.conf
 NAMESERVER=`grep ^nameserver /etc/resolv.conf | head -1 |awk '{print $2}'`
 if [ -z $NAMESERVER ]; then NAMESERVER='127.0.0.1'; fi
-read -e -p "Enter the DNS nameserver to use for the Overcloud: " -i $NAMESERVER NAMESERVER
+
+if [ $interactive == true ]; then
+  read -e -p "Enter the DNS nameserver to use for the Overcloud: " -i $NAMESERVER NAMESERVER
+else
+  NAMESERVER=`grep ^nameserver $CONF_FILE | awk '{print $2}'`
+fi
+
 grep -q $NAMESERVER /etc/resolv.conf || echo "nameserver $NAMESERVER" >> /etc/resolv.conf
 
 # Store public ip address for later
@@ -53,7 +92,7 @@ MYADDR=`fusor-undercloud-configurator get-addr`
 set -e
 
 # Prompt user for network setup and write the undercloud config file
-sudo -u stack python -u /usr/sbin/fusor-undercloud-configurator
+sudo -E -u stack python -u /usr/sbin/fusor-undercloud-configurator
 
 # call out to egon to run the undercloud installer
 cd /home/stack

--- a/bin/fusor-undercloud-installer
+++ b/bin/fusor-undercloud-installer
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-fusor-undercloud-install 2>&1 | tee /var/log/fusor-undercloud-install.log
+fusor-undercloud-install "$@" 2>&1 | tee /var/log/fusor-undercloud-install.log

--- a/config/fusor-undercloud-installer.answers.yaml
+++ b/config/fusor-undercloud-installer.answers.yaml
@@ -1,0 +1,46 @@
+# Format:
+# <classname>:
+#   <param>: <value> - include and override the default(s)
+#
+# The minimum information is filled in by default, all advanced options
+# can be left blank if the default is desired. If specifying advanced
+# options, ensure that the 'specify' parameter is set to 'True'
+---
+undercloud:
+  provisioning_nic: eth1
+  ip_addr: 192.0.2.0/24
+  gateway: 192.0.2.1
+  undercloud_ip: 192.0.2.254
+hostname: instack.example.com
+nameserver: 127.0.0.1
+password:
+  admin_password: dog8code
+advanced:
+  specify: False
+  image_path:
+  undercloud_public_vip:
+  undercloud_admin_vip:
+  dhcp_start:
+  dhcp_end:
+  discovery_interface:
+  undercloud_debug:
+  undercloud_db_password:
+  undercloud_admin_token:
+  undercloud_glance_password:
+  undercloud_heat_encryption_key:
+  undercloud_heat_password:
+  undercloud_neutron_password:
+  undercloud_nova_password:
+  undercloud_ironic_password:
+  undercloud_tuskar_password:
+  undercloud_ceilometer_password:
+  undercloud_ceilometer_metering_secret:
+  undercloud_ceilometer_snmpd_user:
+  undercloud_ceilometer_snmpd_password:
+  undercloud_swift_password:
+  undercloud_rabbit_cookie:
+  undercloud_rabbit_password:
+  undercloud_rabbit_username:
+  undercloud_heat_stack_domain_admin_password:
+  undercloud_swift_hash_suffix:
+


### PR DESCRIPTION
Undercloud installer now accepts an answer file. Can be run as 'fusor-undercloud-installer --non-interactive' or 'fusor-undercloud-installer --answer-file=**_' where '**_' is the path. If the answer file is left blank, the default
