### PR TITLE
avoid duplicate statements in sysctl.conf

### DIFF
--- a/bin/fusor-undercloud-installer
+++ b/bin/fusor-undercloud-installer
@@ -57,7 +57,12 @@ enabled=1" > /etc/yum.repos.d/fake.repo
   set -e
 
   # enable IP forwarding
-  echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
+  if grep -q "net.ipv4.ip_forward" /etc/sysctl.conf
+  then
+      sed -i 's/net.ipv4.ip_forward[ ]*=[ ]*0/net.ipv4.ip_forward = 1/' /tmp/sysctl.conf
+  else
+      echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
+  fi
   sysctl -p /etc/sysctl.conf
 
   # Grab the desired hostname from answer file if specified


### PR DESCRIPTION
When running fusor-undercloud-installer multiple times we keep adding `net.ipv4.ip_forward = 1` to `/etc/sysctl.conf`. This change looks to see if there is already an entry, if it is it will change it to equal 1 even if it is already 1 just becomes a noop. If it doesn't exist we append to the file.
