### PR TITLE
invalid filename for sysctl.

### DIFF
--- a/bin/fusor-undercloud-installer
+++ b/bin/fusor-undercloud-installer
@@ -59,7 +59,7 @@ enabled=1" > /etc/yum.repos.d/fake.repo
   # enable IP forwarding
   if grep -q "net.ipv4.ip_forward" /etc/sysctl.conf
   then
-      sed -i 's/net.ipv4.ip_forward[ ]*=[ ]*0/net.ipv4.ip_forward = 1/' /tmp/sysctl.conf
+      sed -i 's/net.ipv4.ip_forward[ ]*=[ ]*0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf
   else
       echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
   fi


### PR DESCRIPTION
/tmp/sysctl.conf doesn't exist which causes an error. You only see
it if ip_forward exists in sysctl.conf
