### PR TITLE
only add user if it doesn't exist.

### DIFF
--- a/bin/fusor-undercloud-installer
+++ b/bin/fusor-undercloud-installer
@@ -31,7 +31,10 @@ fusor_undercloud_install() {
   export CONF_FILE
 
   # create stack user, become her
-  useradd stack
+  id -u stack >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    useradd stack
+  fi
   echo "stack ALL=(root) NOPASSWD:ALL" >> /etc/sudoers.d/stack
   chmod 0440 /etc/sudoers.d/stack
 


### PR DESCRIPTION
If stack exists, don't try to create it. There are still more to do to allow the installer to run multiple times. We should be more defensive.
