### PR TITLE
1323569 - Added extra validations for hostname and nameserver address

### DIFF
--- a/bin/fusor-undercloud-installer
+++ b/bin/fusor-undercloud-installer
@@ -68,7 +68,7 @@ enabled=1" > /etc/yum.repos.d/fake.repo
   fi
   sysctl -p /etc/sysctl.conf
 
-  ValidHostnameRegex='^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$'
+  ValidHostnameRegex='(?=^.{1,254}$)(^(?>(?!\d+\.)[a-zA-Z0-9_\-]{1,63}\.?)+(?:[a-zA-Z]{2,})$)'
   ValidIpAddressRegex='^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'
   ValidInput=false
 
@@ -84,7 +84,7 @@ enabled=1" > /etc/yum.repos.d/fake.repo
       HOST=`grep ^hostname $CONF_FILE | awk '{print $2}'`
     fi
 
-    if [[ $HOST =~ $ValidHostnameRegex ]]
+    if [[ `echo $HOST | grep -P $ValidHostnameRegex` ]]
     then
       echo "Hostname is in valid format, setting hostname"
       ValidInput=true
@@ -120,10 +120,21 @@ enabled=1" > /etc/yum.repos.d/fake.repo
     else
       NAMESERVER=`grep ^nameserver $CONF_FILE | awk '{print $2}'`
     fi
-    if [[  $NAMESERVER =~ $ValidIpAddressRegex  ]]
+    if [[ $NAMESERVER =~ $ValidIpAddressRegex ]]
     then
-      echo "Nameserver IP address is valid"
-      ValidInput=true
+      FailedCheck=false
+      for i in 1 2 3 4; do
+        if [ $(echo "$NAMESERVER" | cut -d. -f$i) -gt 255 ]; then
+          echo "Specified nameserver is not a valid IP address"
+          NAMESERVERPROMPT=$NAMESERVER
+          FailedCheck=true
+          break
+        fi
+      done
+      if [ $FailedCheck == false ]; then
+        echo "Nameserver IP address is valid"
+        ValidInput=true
+      fi
     else
       # when input is not empty, use input as prompt
       # by default prmopt is last non-empty value


### PR DESCRIPTION
Changed hostname regex to use a lookahead so that it's cleaner and checks for valid FQDNs rather than just checking for valid alphanumeric values. 

Also changed the nameserver IP address prompt to ensure that all values are under 256.

Link to bug: https://bugzilla.redhat.com/show_bug.cgi?id=1325369
